### PR TITLE
Feat/7 task upload interview data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+data/raw/*.csv filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ git cloneでプロジェクトをcloneしてきた後は仮想環境を作成し
 
 - `git clone` した後１度だけ `git lfs install` を行って、ローカルリポジトリに **Git LFSを導入** して下さい。
 - ブランチを取得してきたときはファイルポインタのみ取得されます。
-  `git lfs pull` でファイルの実態を取得できます。
+  `git lfs pull` でファイルの実体を取得できます。
   なお、特定のファイルだけpullしたいときは以下のようなコマンドです。
   `git lfs pull --include="data/raw/bill-of-lading_messages.csv"`
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ git cloneでプロジェクトをcloneしてきた後は仮想環境を作成し
 **作業する前は必ず仮想化の有効化を行って下さい！**
 `source .venv/bin/activete`
 
+## Git LFS のインストール
+
+解析で使用するデータが少し大きいです。
+そのデータをgit管理してしまうとブランチを取得するたびにデータも取得してしまい容量を圧迫してしまいます。
+そのためGit LFS（Large File Storage）という機能を使います。　（Github公式の機能）
+
+- `git clone` した後１度だけ `git lfs install` を行って、ローカルリポジトリに **Git LFSを導入** して下さい。
+- ブランチを取得してきたときはファイルポインタのみ取得されます。
+  `git lfs pull` でファイルの実態を取得できます。
+  なお、特定のファイルだけpullしたいときは以下のようなコマンドです。
+  `git lfs pull --include="data/raw/bill-of-lading_messages.csv"`
+
 ## commit前のチェック＆整形
 
 プログラムソースの一貫性を保つため

--- a/data/raw/bill-of-lading_interview_sessions.csv
+++ b/data/raw/bill-of-lading_interview_sessions.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2ceded843a01064b268ac0cfdd4b39264b7e9aea5f3761bb463aacf577cba87
+size 2884891

--- a/data/raw/bill-of-lading_messages.csv
+++ b/data/raw/bill-of-lading_messages.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:921ce4c5c8697decb0761179bc95747711e017a0cdfbee034b376c9b5edd94f5
+size 3541879


### PR DESCRIPTION
このプルリクエストは、プロジェクトにGit LFS（Large File Storage）を導入し、大容量データファイルを効率的に管理できるようにします。また、Git LFSの使用方法を案内するドキュメント（README）も更新されています。さらに、2つの大容量CSVデータファイルがリポジトリに追加され、Git LFSで管理されるようになっています。

**Git LFSの導入とドキュメント更新:**

* `.gitattributes` にエントリを追加し、`data/raw/` 配下のすべてのCSVファイルをGit LFSで管理するように設定しました。これにより、大容量ファイルを効率的に扱えるようになります。
* Git LFSのインストール方法や使い方、大容量データファイルを取得する手順をREADMEに追記しました。

**データファイルの追加:**

* `data/raw/bill-of-lading_interview_sessions.csv`（約2.9 MB）を追加し、Git LFSで管理するようにしました。
* `data/raw/bill-of-lading_messages.csv`（約3.5 MB）を追加し、Git LFSで管理するようにしました。

fix #7 
